### PR TITLE
Refactor/main

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,11 @@
+/**
+ * e-amusement Maintenance Bot
+ * server.js
+ * authored by twitter/@anericzhang
+ * creation date: 10/10/22
+ * repository: https://github.com/theericzhang/eamuse-maintenance-bot
+ */
+
 import { TwitterApi } from "twitter-api-v2";
 import express from "express";
 import "dotenv/config";
@@ -39,6 +47,10 @@ let extendedMaintenancePostedFlags = {
     postedEndedNotice : false
 };
 
+/**
+ * Resets all truth flags used to guard the postTweet() function.
+ * @returns {void} - all truth flags from extendedMaintenancePostedFlags will be set to false 
+ */
 function resetFlags() {
     Object.keys(extendedMaintenancePostedFlags).forEach((flag) => extendedMaintenancePostedFlags[flag] = false);
 }

--- a/server.js
+++ b/server.js
@@ -43,14 +43,62 @@ function resetFlags() {
     Object.keys(extendedMaintenancePostedFlags).forEach((flag) => extendedMaintenancePostedFlags[flag] = false);
 }
 
-// helper function to post tweetBody
-// postTweet() is called when timing conditions are met
+const toLocaleTimeStringOptionsVerbose = { 
+    timeZone: 'America/New_York', 
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+};
+
+const toLocaleTimeStringOptionsShort = { 
+    timeZone: 'America/New_York', 
+    hour: '2-digit',
+    minute: '2-digit'
+};
+
+Object.freeze(toLocaleTimeStringOptionsVerbose);
+Object.freeze(toLocaleTimeStringOptionsShort);
+
+/**
+ * Returns a relevant warning tweet message for the Twitter Client to post
+ * @param {number} index - The message bank contains an array of premade tweets to send. Specify an index to select the message
+ * @param {string} timeStart - The time that extended maintenance starts. Must be passed as myDateObject.toLocaleTimeString('en-US', { timeZone: 'America/New_York'})
+ * @param {string} timeEnd - The time that extended maintenance ends. Must be passed as myDateObject.toLocaleTimeString('en-US', { timeZone: 'America/New_York'})
+ * @returns {string} - Parsed message that contains the relevant time to the message
+ */
+ function getMessage(index, timeStart, timeEnd) {
+    const tweetBodyBank = [
+        `⚠️ Warning - In THREE days, the e-amusement Service will be undergoing extended maintenance, beginning Monday ${timeStart} ET and ending at ${timeEnd} ET`,
+        `⚠️ Warning - The e-amusement Service will be undergoing extended maintenance beginning TOMORROW, Monday ${timeStart} ET and ending at ${timeEnd} ET`,
+        `🚨 Alert - In TWO hours, the e-amusement Service will be starting extended maintenance, beginning at ${timeStart} ET and ending at ${timeEnd} ET`,
+        `🚨 Alert - The e-amusement Service has started extended maintenance. e-amusement is expected to be back online at ${timeEnd} ET`,
+        `⚠️ Notice - The e-amusement Service is expected to be back online in ONE hour, at ${timeEnd} ET`,
+        `✅ Notice - The e-amusement Service is expected to be back online now`
+    ];
+    return tweetBodyBank[index];
+}
+
+/**
+ * Helper function to post tweetBody. This function is called when all timing conditions are met
+ * @param {string} tweetBody - The Tweet body message to be sent to Twitter
+ */
+
 async function postTweet(tweetBody) {
     await clientMain.v1.tweet(tweetBody);
     console.log('Posted! - ', tweetBody);
 }
 
 // key observer function that handles date + time checking for extended maintenance periods
+
+/**
+ * extendedMaintenanceObserver is called every 6 seconds to create a current Date object to compare to 
+ * the expected Extended Maintenance day. Extended Maintenance falls on every third Tuesday from 02:00 to 07:00 JST,
+ * which falls on the Monday prior from 12:00 - 17:00 EST.
+ * @returns {void}. Sends a Tweet to the eamuse_schedule Twitter account. 
+ */
+
 async function extendedMaintenanceObserver() {
     let tweetBody = '';
     const referenceDate = new Date();
@@ -58,24 +106,23 @@ async function extendedMaintenanceObserver() {
 
     // adding 9 to hour count to reflect JST
     referenceDate.setUTCHours(referenceDate.getUTCHours() + timezoneOffsetJapanUTC);
-    // console.log(referenceDate);
     referenceDate.setUTCDate(1);
     console.log('reference date before finding tuesday - expected to be the 1st every time: ' ,referenceDate);
 
     // finds first tuesday and sets referenceDate to it
     while (referenceDate.getUTCDay() !== 2) {
-        console.log('should set here');
         referenceDate.setUTCDate(referenceDate.getUTCDate() + 1);
     }
     console.log('reference date after finding tuesday - expected to be the first tuesday every time: ',referenceDate);
+
     // getting extended maintenance day, which is the third tuesday in Japan. Just add 14 to our recently set referenceDate
     const extendedMaintenanceDay = new Date(referenceDate.setUTCDate(referenceDate.getUTCDate() + 14));
-    console.log('extended ',extendedMaintenanceDay);
+    console.log('extended maintenance day in JP', extendedMaintenanceDay);
 
     // create new time object representing current time in JST
     const currentDate = new Date();
     currentDate.setHours(currentDate.getHours() + timezoneOffsetJapanUTC);
-    console.log('current ', currentDate);
+    console.log('current time in JP', currentDate);
 
     // begin date comparisons - Because our extendedMaintenanceDay date object is set on the third tuesday, we can reference our currentDate object to post warnings
     // when getting values, it is mandatory to getUTC__, otherwise it will show in UTC +0 values
@@ -90,84 +137,77 @@ async function extendedMaintenanceObserver() {
                                     && extendedMaintenanceDay.getUTCMonth() === currentDate.getUTCMonth() 
                                     && extendedMaintenanceDay.getUTCDate() === currentDate.getUTCDate();
     
-    // begin time comparisons - Because the time portion to extendedMaintenanceDay is set in JST, we can manually check to see if the hours fall on maintenance times
-    // extended maintenance happens from 2am-7am JST
-    // an additional condition, isPastExtendedMaintenance is needed to determine if all the flags are safe to reset
-    // flags are used to guard the postTweet() function. if a tweet has not been posted yet, its flag value will be false. 
-    // after a tweet has been posted, the flag value will be set to true.
-    // the next time the extendedMaintenanceObserver() will be run, postTweet() will not be run again.
+    /**
+     * begin time comparisons - Because the time portion to extendedMaintenanceDay is set in JST, we can manually check to see if the hours fall on maintenance times
+     * extended maintenance happens from 2am-7am JST
+     * an additional condition, isPastExtendedMaintenance is needed to determine if all the flags are safe to reset
+     * flags are used to guard the postTweet() function. if a tweet has not been posted yet, its flag value will be false. 
+     * after a tweet has been posted, the flag value will be set to true.
+     * the next time the extendedMaintenanceObserver() will be run, postTweet() will not be run again.
+     */
+
     const is2HoursBeforeExtendedMaintenance = isTodayExtendedMaintenance && (extendedMaintenanceDay.getUTCHours() === 0);
     const isExactlyExtendedMaintenance = isTodayExtendedMaintenance && (extendedMaintenanceDay.getUTCHours() === 2);
     const is1HourBeforeExtendedMaintenanceEnds = isTodayExtendedMaintenance && (extendedMaintenanceDay.getUTCHours() === 6);
     const extendedMaintenanceEnds = isTodayExtendedMaintenance && (extendedMaintenanceDay.getUTCHours() === 7 && extendedMaintenanceDay.getUTCMinutes() < 1);
     const isPastExtendedMaintenance = isTodayExtendedMaintenance && (extendedMaintenanceDay.getUTCHours() === 7 && extendedMaintenanceDay.getUTCMinutes() >= 1);
     
+    // Create an extended maintenance day time start object and set it to 02:00 JST (17:00 UTC +0)
     const extendedMaintenanceDayTimeStart = new Date(extendedMaintenanceDay);
-    // 1PM ET
     extendedMaintenanceDayTimeStart.setUTCHours(17, 0, 0, 0);
 
-    console.log('maintenance starts: ', extendedMaintenanceDayTimeStart.toLocaleString('en-US', { timeZone: 'America/New_York', year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit'}));
-
+    // Create an extended maintenance day time end object and set it to 07:00 JST (22:00 UTC +0)
     const extendedMaintenanceDayTimeEnd = new Date(extendedMaintenanceDay);
-    // 6PM ET
     extendedMaintenanceDayTimeEnd.setUTCHours(22, 0, 0, 0);
 
-    console.log('maintenance ends: ', extendedMaintenanceDayTimeEnd.toLocaleString('en-US', { timeZone: 'America/New_York', year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit'}));
+    /**
+     * Set the date one day behind to reflect the Monday before the third Tuesday.
+     * These date objects, containing when extended maintenance will begin and end in the US/NY timezone,
+     * will be passed to getMessage(). These will NOT be used to compare extended maintenance dates to current date.
+     */
 
     extendedMaintenanceDayTimeStart.setDate(extendedMaintenanceDayTimeEnd.getDate() - 1);
     extendedMaintenanceDayTimeEnd.setDate(extendedMaintenanceDayTimeEnd.getDate() - 1);
 
     // checking if conditions we set are true. if they are, set the tweetBody, postTweet, and set the flags to true.
     if (is3DaysBeforeExtendedMaintenance) {
-        tweetBody = `⚠️ Warning - In THREE days, the e-amusement service will be undergoing extended maintenance, beginning Monday ${extendedMaintenanceDayTimeStart.toLocaleString('en-US', { timeZone: 'America/New_York', year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit'})} ET and ending at ${extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', { timeZone: 'America/New_York'})} ET`;
+        tweetBody = getMessage(0, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsVerbose), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.posted3DayWarning && postTweet(tweetBody);
         extendedMaintenancePostedFlags.posted3DayWarning = true;
     } else if (is1DayBeforeExtendedMaintenance) {
-        tweetBody = `⚠️ Warning - The e-amusement service will be undergoing extended maintenance beginning TOMORROW, Monday ${extendedMaintenanceDayTimeStart.toLocaleString('en-US', { timeZone: 'America/New_York', year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit'})} ET and ending at ${extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', { timeZone: 'America/New_York'})} ET`;
+        tweetBody = getMessage(1, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsVerbose), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.posted24HourWarning && postTweet(tweetBody);
         extendedMaintenancePostedFlags.posted24HourWarning = true;
     } else if (is2HoursBeforeExtendedMaintenance) {
-        tweetBody = `🚨 Alert - In TWO hours, the e-amusement service will be starting extended maintenance, beginning at ${extendedMaintenanceDayTimeStart.toLocaleTimeString('en-US', { timeZone: 'America/New_York', hour: '2-digit',
-        minute: '2-digit'})} ET and ending at ${extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', { timeZone: 'America/New_York'})} ET`;
+        tweetBody = getMessage(2, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.posted2HourWarning && postTweet(tweetBody);
         extendedMaintenancePostedFlags.posted2HourWarning = true;
     } else if (isExactlyExtendedMaintenance) {
-        tweetBody = `🚨 Alert - The e-amusement service has started extended maintenance. e-amusement is expected to be back online at ${extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', { timeZone: 'America/New_York', hour: '2-digit',
-        minute: '2-digit'})} ET`;
+        tweetBody = getMessage(3, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.postedBeginsWarning && postTweet(tweetBody);
         extendedMaintenancePostedFlags.postedBeginsWarning = true;
     } else if (is1HourBeforeExtendedMaintenanceEnds) {
-        tweetBody = `⚠️ Notice - The e-amusement service is expected to be back online in ONE hour, at ${extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', { timeZone: 'America/New_York', hour: '2-digit',
-        minute: '2-digit'})} ET`;
+        tweetBody = getMessage(4, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.postedEndsIn1HourNotice && postTweet(tweetBody);
         extendedMaintenancePostedFlags.postedEndsIn1HourNotice = true;
     } else if (extendedMaintenanceEnds) {
-        tweetBody = `✅ Notice - The e-amusement service is expected to be back online now`;
+        tweetBody = getMessage(5, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.postedEndedNotice && !isPastExtendedMaintenance && postTweet(tweetBody);
         extendedMaintenancePostedFlags.postedEndedNotice = true;
     }
+
+    console.log('maintenance in US/NY starts:', extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsVerbose));
+    console.log('maintenance in US/NY ends:', extendedMaintenanceDayTimeEnd.toLocaleString('en-US', toLocaleTimeStringOptionsVerbose));
+
+    console.log('maintenance in JP/TOKYO starts:', extendedMaintenanceDayTimeStart.toLocaleString('en-US', {...toLocaleTimeStringOptionsVerbose, timeZone: "Asia/Tokyo"}));
+    console.log('maintenance in JP/TOKYO ends:', extendedMaintenanceDayTimeEnd.toLocaleString('en-US', {...toLocaleTimeStringOptionsVerbose, timeZone: "Asia/Tokyo"}));
+    console.log('\n');
 
     // check that all flags are true. this will signal that flags are ready to be reset.
     const readyToBeReset = Object.values(extendedMaintenancePostedFlags).every((flagValue) => {
@@ -177,7 +217,6 @@ async function extendedMaintenanceObserver() {
     // reset the flags, making sure to also check that it's past maintenance. 
     // why? there is an edge case that it is 7:00am JST and 
     readyToBeReset && isPastExtendedMaintenance && resetFlags();
-    console.log('\n');
     return;
 }
 


### PR DESCRIPTION
## Changes

In order to preemptively stop the instance from calling `postTweet()` twice, we must guard the `postTweet()` function with a flag - `isCurrentlyPosting`

# What happened before

```js
if (is3DaysBeforeExtendedMaintenance) {
    tweetBody = 'abc';
    !extendedMaintenancePostedFlags.posted3DayWarning && postTweet(tweetBody);
    // etc
}
```

Since this `if` block is wrapped in a `setInterval(() => {}, 6000)`, it will evaluate every 6 seconds. 

`postTweet()` is a HOF that uses the Twitter-API-v1 endpoint function, `v1.tweet()`.

`v1.tweet()` returns a Promise that awaits the POST request to complete before resolving.

There is a chance that the Promise will not resolve in 6 seconds, so `postTweet()` will run again and queue another Promise.

Since there are two `v1.tweet()` functions on the call stack with the same `tweetBody`, the endpoint will throw an error, close connection, and crash our app.

# Solution

```js
let isCurrentlyPosting = false;

async function postTweet(tweetBody) {
    // set isCurrentlyPosting flag to true
    isCurrentlyPosting = true;
    await clientMain.v1.tweet(tweetBody);
    // set isCurrentlyPosting flag to false
    isCurrentlyPosting = false;
    console.log('Posted! - ', tweetBody);
}

async function extendedMaintenanceObserver() {
    !isCurrentlyPosting && postTweet();
}
```

By creating a flag and setting these values inside the HOF, we can block the thread from advancing and accessing `postTweet()` again. 

