### PR TITLE
Pacific time zone feat/main

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ node server.js
 * Low sev bug fix - https://github.com/theericzhang/eamuse-maintenance-bot/issues/1
 * Migration to Azure once Heroku ends free Dynos (Completed 12/1)
 ### In Progress
+* West Coast time zone addition to tweets
 ### Next Up
 * Place upcoming Extended Maintenance information in bio for quick access
 * Weekday maintenance warning implementation (?)

--- a/server.js
+++ b/server.js
@@ -210,32 +210,62 @@ async function extendedMaintenanceObserver() {
 
     // checking if conditions we set are true. if they are, set the tweetBody, postTweet, and set the flags to true.
     if (is3DaysBeforeExtendedMaintenance) {
-        tweetBody = getMessage(0, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsVerbose), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
+        tweetBody = getMessage(
+            0, 
+            extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleDateStringOptions), 
+            extendedMaintenanceDayTimeStart, 
+            extendedMaintenanceDayTimeEnd
+        );
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.posted3DayWarning && !isCurrentlyPosting && postTweet(tweetBody);
         extendedMaintenancePostedFlags.posted3DayWarning = true;
     } else if (is1DayBeforeExtendedMaintenance) {
-        tweetBody = getMessage(1, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsVerbose), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
+        tweetBody = getMessage(
+            1, 
+            extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleDateStringOptions), 
+            extendedMaintenanceDayTimeStart, 
+            extendedMaintenanceDayTimeEnd
+        );
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.posted24HourWarning && !isCurrentlyPosting && postTweet(tweetBody);
         extendedMaintenancePostedFlags.posted24HourWarning = true;
     } else if (is2HoursBeforeExtendedMaintenance) {
-        tweetBody = getMessage(2, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
+        tweetBody = getMessage(
+            2, 
+            extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleDateStringOptions), 
+            extendedMaintenanceDayTimeStart, 
+            extendedMaintenanceDayTimeEnd
+        );
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.posted2HourWarning && !isCurrentlyPosting && postTweet(tweetBody);
         extendedMaintenancePostedFlags.posted2HourWarning = true;
     } else if (isExactlyExtendedMaintenance) {
-        tweetBody = getMessage(3, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
+        tweetBody = getMessage(
+            3, 
+            extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleDateStringOptions), 
+            extendedMaintenanceDayTimeStart, 
+            extendedMaintenanceDayTimeEnd
+        );
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.postedBeginsWarning && !isCurrentlyPosting && postTweet(tweetBody);
         extendedMaintenancePostedFlags.postedBeginsWarning = true;
     } else if (is1HourBeforeExtendedMaintenanceEnds) {
-        tweetBody = getMessage(4, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
+        tweetBody = getMessage(
+            4, 
+            extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleDateStringOptions), 
+            extendedMaintenanceDayTimeStart, 
+            extendedMaintenanceDayTimeEnd
+        );
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.postedEndsIn1HourNotice && !isCurrentlyPosting && postTweet(tweetBody);
         extendedMaintenancePostedFlags.postedEndsIn1HourNotice = true;
     } else if (extendedMaintenanceEnds) {
-        tweetBody = getMessage(5, extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleTimeStringOptionsShort), extendedMaintenanceDayTimeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShort));
+        tweetBody = getMessage(
+            5, 
+            extendedMaintenanceDayTimeStart.toLocaleString('en-US', toLocaleDateStringOptions), 
+            extendedMaintenanceDayTimeStart, 
+            extendedMaintenanceDayTimeEnd
+        );
         // post tweetBody if postedFlag value is false
         !extendedMaintenancePostedFlags.postedEndedNotice && !isCurrentlyPosting && !isPastExtendedMaintenance && postTweet(tweetBody);
         extendedMaintenancePostedFlags.postedEndedNotice = true;

--- a/server.js
+++ b/server.js
@@ -65,30 +65,46 @@ const toLocaleTimeStringOptionsVerbose = {
     minute: '2-digit'
 };
 
-const toLocaleTimeStringOptionsShort = { 
+const toLocaleTimeStringOptionsShortET = { 
     timeZone: 'America/New_York', 
     hour: '2-digit',
     minute: '2-digit'
 };
 
+const toLocaleTimeStringOptionsShortPT = {
+    timeZone: 'America/Los_Angeles',
+    hour: '2-digit',
+    minute: '2-digit'
+};
+
+const toLocaleDateStringOptions = {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+};
+
 // prevent edits to locale options
 Object.freeze(toLocaleTimeStringOptionsVerbose);
-Object.freeze(toLocaleTimeStringOptionsShort);
+Object.freeze(toLocaleTimeStringOptionsShortET);
+Object.freeze(toLocaleTimeStringOptionsShortPT);
+Object.freeze(toLocaleDateStringOptions);
 
 /**
  * Returns a relevant warning tweet message for the Twitter Client to post
  * @param {number} index - The message bank contains an array of premade tweets to send. Specify an index to select the message
- * @param {string} timeStart - The time that extended maintenance starts. Must be passed as myDateObject.toLocaleTimeString('en-US', { timeZone: 'America/New_York'})
- * @param {string} timeEnd - The time that extended maintenance ends. Must be passed as myDateObject.toLocaleTimeString('en-US', { timeZone: 'America/New_York'})
+ * @param {string} dateOfMaintenance - The start date of the maintenance day, passed as a string. must be passed as .toLocaleString('en-US', toLocaleDateStringOptions) 
+ * @param {Date} timeStart - The time that extended maintenance starts. Must be passed as a pure date object
+ * @param {Date} timeEnd - The time that extended maintenance ends. Must be passed as a pure date object
  * @returns {string} - Parsed message that contains the relevant time to the message
  */
- function getMessage(index, timeStart, timeEnd) {
+ function getMessage(index, dateOfMaintenance, timeStart, timeEnd) {
     const tweetBodyBank = [
-        `⚠️ Warning - In THREE days, the e-amusement Service will be undergoing extended maintenance, beginning Monday ${timeStart} ET and ending at ${timeEnd} ET`,
-        `⚠️ Warning - The e-amusement Service will be undergoing extended maintenance beginning TOMORROW, Monday ${timeStart} ET and ending at ${timeEnd} ET`,
-        `🚨 Alert - In TWO hours, the e-amusement Service will be starting extended maintenance, beginning at ${timeStart} ET and ending at ${timeEnd} ET`,
-        `🚨 Alert - The e-amusement Service has started extended maintenance. e-amusement is expected to be back online at ${timeEnd} ET`,
-        `⚠️ Notice - The e-amusement Service is expected to be back online in ONE hour, at ${timeEnd} ET`,
+        `⚠️ Warning - In THREE days, the e-amusement Service will be undergoing extended maintenance:\n\nMonday, ${dateOfMaintenance}\nBegins: ${timeStart.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeStart.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT \nEnds: ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT`,
+        `⚠️ Warning - The e-amusement Service will be undergoing extended maintenance TOMORROW:\n\nMonday, ${dateOfMaintenance}\nBegins: ${timeStart.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeStart.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT \nEnds: ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT`,
+        `🚨 Alert - In TWO hours, the e-amusement Service will be starting extended maintenance:\n\nBegins: ${timeStart.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeStart.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT \nEnds: ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT`,
+        `🚨 Alert - The e-amusement Service has started extended maintenance. e-amusement is expected to be back online at ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT`,
+        `⚠️ Notice - The e-amusement Service is expected to be back online in ONE hour, at ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortET)} ET / ${timeEnd.toLocaleTimeString('en-US', toLocaleTimeStringOptionsShortPT)} PT`,
         `✅ Notice - The e-amusement Service is expected to be back online now`
     ];
     return tweetBodyBank[index];


### PR DESCRIPTION
# Changes

- `tweetBodyBank` tweets have changed to accommodate for the Pacific timezone
- Tweeted messages will now reflect both ET and PT timezones, for example:

```
/* SIMULATED OUTPUT */

⚠️ Warning - The e-amusement Service will be undergoing extended maintenance TOMORROW:

Monday, 12/19/2022
Begins: 12:00 PM ET / 09:00 AM PT 
Ends: 05:00 PM ET / 02:00 PM PT
```